### PR TITLE
Fix button input drops

### DIFF
--- a/nuxbt/controller/input.py
+++ b/nuxbt/controller/input.py
@@ -132,6 +132,10 @@ class InputParser():
         if state:
             finished = state["finished_macros"]
             finished.append(macro_id)
+            # Prune to prevent unbounded growth - the caller only
+            # checks for a single macro_id, so keep the last few.
+            if len(finished) > 20:
+                finished = finished[-5:]
             state["finished_macros"] = finished
 
         return

--- a/nuxbt/controller/server.py
+++ b/nuxbt/controller/server.py
@@ -160,9 +160,15 @@ class ControllerServer():
                 self.logger.debug(format_msg_controller(msg))
 
             try:
-                # Cache the last packet to prevent overloading the switch
-                # with packets on the "Change Grip/Order" menu.
-                if msg[3:] != self.cached_msg:
+                # When active input is queued (buttons held/macro running),
+                # always send so the Switch sees continuous reports and
+                # a single lost BT packet doesn't drop the input.
+                if self.input.active_input_queued():
+                    itr.sendall(msg)
+                    self.cached_msg = msg[3:]
+                # If nothing is pressed, just send the message once and cache it
+                # to prevent overloading the switch with packets on the "Change Grip/Order" menu. 
+                elif msg[3:] != self.cached_msg:
                     itr.sendall(msg)
                     self.cached_msg = msg[3:]
                 # Send a blank packet every so often to keep the Switch


### PR DESCRIPTION
Fix for the following problems:
1. Caching is used to not overload the switch with messages. This can cause lost button press losses, when the single sent button press message gets lost. Therefore the chaching/not send logic is not used during button presses/macros.

2. The finished queue in input.py grows infinitely large. Therefore older messages get dropped now.
