### PR TITLE
fix: recreate the web controller with the server event

### DIFF
--- a/nuxbt/web/static/js/main.js
+++ b/nuxbt/web/static/js/main.js
@@ -533,7 +533,7 @@ function shutdownController() {
 }
 
 function recreateProController() {
-    socket.emit('create_pro_controller');
+    socket.emit('web_create_pro_controller');
 }
 
 function restartController() {


### PR DESCRIPTION
## Summary
- use the same `web_create_pro_controller` socket event for controller recreation that the initial create action already uses
- keep the restart flow aligned with the Flask-SocketIO handler in `nuxbt/web/app.py`

## Validation
- `node --check nuxbt/web/static/js/main.js`
- verified the existing initial create path and backend handler both use `web_create_pro_controller`

Closes #65