### PR TITLE
fix(controller): shared state fallback for dropped direct input release events

### DIFF
--- a/nuxbt/bluez.py
+++ b/nuxbt/bluez.py
@@ -345,10 +345,13 @@ def _run_command(command):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
 
-    cmd_err = result.stderr.decode("utf-8").replace("\n", "")
-    if cmd_err != "":
-        raise Exception(cmd_err)
-    
+    # Judge success by the exit code, not by whether anything was written to
+    # stderr. Tools like hcitool/hciconfig emit warnings to stderr even on
+    # success, which would otherwise be misread as a failure.
+    if result.returncode != 0:
+        cmd_err = result.stderr.decode("utf-8").replace("\n", "").strip()
+        raise Exception(cmd_err or f"Command failed: {' '.join(command)}")
+
     return result
 
 
@@ -585,9 +588,11 @@ class BlueZ():
         dev_id = int(self.device_id.replace("hci", ""))
         
         sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_RAW, socket.BTPROTO_HCI)
-        sock.bind((dev_id,))
-        sock.send(pkt)
-        sock.close()
+        try:
+            sock.bind((dev_id,))
+            sock.send(pkt)
+        finally:
+            sock.close()
 
     def set_class(self, device_class):
         self.logger.info(f"Setting adapter class to {device_class}")
@@ -1070,8 +1075,10 @@ class BlueZ():
                 "Alias").upper()
 
             if device_conn_status:
-                if alias_filter and device_alias == alias_filter.upper():
-                    conn_devices.append(path)
+                if alias_filter:
+                    # Only track devices matching the requested alias
+                    if device_alias == alias_filter.upper():
+                        conn_devices.append(path)
                 else:
                     conn_devices.append(path)
 

--- a/nuxbt/controller/input.py
+++ b/nuxbt/controller/input.py
@@ -1,5 +1,5 @@
 from time import perf_counter
-from json import dumps
+from json import dumps, loads
 
 
 DIRECT_INPUT_IDLE_PACKET = {
@@ -96,7 +96,14 @@ class InputParser():
         # The start time for the current macro commands
         self.macro_timer_start = 0
 
-        self.controller_input = None
+        # The latest direct-input packet. Held (not consumed) so the mainloop
+        # can re-apply it on every send: the protocol report is ephemeral
+        # (get_report() clears it and process_commands() rebuilds a neutral
+        # baseline each cycle), so a held button/stick must be re-parsed every
+        # loop or the resends between input events would carry a neutral report
+        # and the input would stutter. Starts idle so active/idle checks are
+        # correct before the first event arrives.
+        self.controller_input = loads(dumps(DIRECT_INPUT_IDLE_PACKET))
 
         # Whether or not input has been entered
         # that would close the "Change Grip/Order" menu
@@ -181,10 +188,12 @@ class InputParser():
 
     def set_protocol_input(self, state=None):
 
-        # Act on direct input if we're not getting idle packets
+        # Act on direct input if we're not getting idle packets. Re-applied
+        # every cycle (not consumed): the protocol report is rebuilt fresh each
+        # loop, so a held input must be re-parsed each time or resends between
+        # input events would send a neutral report and the input would stutter.
         if dumps(self.controller_input) != dumps(DIRECT_INPUT_IDLE_PACKET):
             self.parse_controller_input(self.controller_input)
-            self.controller_input = None
 
         elif (self.macro_buffer or self.current_macro or
               self.current_macro_commands):

--- a/nuxbt/controller/input.py
+++ b/nuxbt/controller/input.py
@@ -253,10 +253,15 @@ class InputParser():
             upper[0] = '1'
 
         # Shared byte
+        # Switch HID shared button byte: bit 0 = Minus, bit 1 = Plus. Here the
+        # bit array is MSB-first (shared[7] is bit 0), so Minus -> shared[7] and
+        # Plus -> shared[6]. This matches the macro path (set_macro_input) and
+        # fixes a swap that previously made direct input report Plus as Minus
+        # and vice versa.
         if controller_input["MINUS"]:
-            shared[6] = '1'
-        if controller_input["PLUS"]:
             shared[7] = '1'
+        if controller_input["PLUS"]:
+            shared[6] = '1'
         if controller_input["R_STICK"]["PRESSED"]:
             shared[5] = '1'
         if controller_input["L_STICK"]["PRESSED"]:

--- a/nuxbt/controller/server.py
+++ b/nuxbt/controller/server.py
@@ -3,11 +3,11 @@ import fcntl
 import os
 import time
 import queue
+import select
 import logging
 import traceback
 import atexit
 from threading import Thread
-import statistics as stat
 
 from .controller import Controller, ControllerTypes
 from ..bluez import BlueZ, find_devices_by_alias
@@ -61,11 +61,6 @@ class ControllerServer():
 
         self.input = InputParser(self.protocol)
 
-        # Debug timekeeping storage array
-        self.times = []
-
-        # Initial reconnection overload protection
-        self.tick = 1
         self.cached_msg = ''
 
     def run(self, reconnect_address=None):
@@ -116,23 +111,48 @@ class ControllerServer():
                 self.logger.debug("Error during graceful shutdown:")
                 self.logger.debug(traceback.format_exc())
 
+    # While active input is held (button down/stick tilted/macro running)
+    # we resend at the Bluetooth interval so a single lost packet doesn't
+    # drop the input and so macro timing keeps advancing.
+    ACTIVE_INTERVAL = 1 / 132
+    # When idle, send a keepalive report every so often so the Switch
+    # doesn't drop the controller (replaces the old tick >= 132 counter).
+    KEEPALIVE_INTERVAL = 1.0
+
     def mainloop(self, itr, ctrl):
 
-        duration_start = time.perf_counter()
-        while True:
-            # Start timing command processing
-            timer_start = time.perf_counter()
+        # The interrupt socket plus the task queue's read end form the set of
+        # event sources. select() blocks until the Switch sends something, an
+        # input/macro event arrives, or the timeout fires, instead of polling
+        # shared state on a fixed timer.
+        if self.task_queue is not None:
+            queue_reader = self.task_queue._reader
+        else:
+            queue_reader = None
 
-            # Attempt to get output from Switch
+        while True:
+            # Hold/macro active -> wake at the BT interval to keep resending.
+            # Idle -> wake at the keepalive interval.
+            timeout = (self.ACTIVE_INTERVAL
+                       if self.input.active_input_queued()
+                       else self.KEEPALIVE_INTERVAL)
+
+            read_set = [itr] if queue_reader is None else [itr, queue_reader]
+            readable, _, _ = select.select(read_set, [], [], timeout)
+            timed_out = not readable
+
+            # Attempt to get output from Switch (itr stays non-blocking)
             try:
                 reply = itr.recv(50)
-                if len(reply) > 40:
+                if self.logger_level <= logging.DEBUG and len(reply) > 40:
                     self.logger.debug(format_msg_switch(reply))
             except BlockingIOError:
                 reply = None
 
-            # Getting any inputs from the task queue
-            if self.task_queue:
+            # Drain the task queue every loop. This is cheap when empty and
+            # avoids missed wakeups from the Queue's internal buffer being out
+            # of sync with the pipe that select() watches.
+            if self.task_queue is not None:
                 try:
                     while True:
                         msg = self.task_queue.get_nowait()
@@ -144,12 +164,10 @@ class ControllerServer():
                                 msg["macro_id"], state=self.state)
                         elif msg and msg["type"] == "clear":
                             self.input.clear_macros()
+                        elif msg and msg["type"] == "direct":
+                            self.input.set_controller_input(msg["input"])
                 except queue.Empty:
                     pass
-
-            # Set Direct Input
-            if self.state["direct_input"]:
-                self.input.set_controller_input(self.state["direct_input"])
 
             self.protocol.process_commands(reply)
             self.input.set_protocol_input(state=self.state)
@@ -166,42 +184,23 @@ class ControllerServer():
                 if self.input.active_input_queued():
                     itr.sendall(msg)
                     self.cached_msg = msg[3:]
-                    self.tick = 0
-                # If nothing is pressed, just send the message once and cache it
-                # to prevent overloading the switch with packets on the "Change Grip/Order" menu. 
+                # If the report changed (input change or a subcommand reply
+                # from the Switch), send it once and cache it to avoid
+                # flooding the Switch on the "Change Grip/Order" menu.
                 elif msg[3:] != self.cached_msg:
                     itr.sendall(msg)
                     self.cached_msg = msg[3:]
-                    self.tick = 0
-                # Send a blank packet every so often to keep the Switch
-                # from disconnecting from the controller.
-                elif self.tick >= 132:
+                # The Switch sent us something that needs a reply.
+                elif reply:
                     itr.sendall(msg)
-                    self.tick = 0
+                # Idle keepalive so the Switch doesn't drop the controller.
+                elif timed_out:
+                    itr.sendall(msg)
             except BlockingIOError:
                 continue
             except OSError as e:
                 # Attempt to reconnect to the Switch
                 itr, ctrl = self.save_connection(e)
-
-            # Figure out how long it took to process commands
-            duration_end = time.perf_counter()
-            duration_elapsed = duration_end - duration_start
-            duration_start = duration_end
-            
-            sleep_time = 1/132 - duration_elapsed
-            if sleep_time >= 0:
-                time.sleep(sleep_time)
-            self.tick += 1
-
-            if self.logger_level <= logging.DEBUG:
-                self.times.append(duration_elapsed)
-                if len(self.times) > 100:
-                    self.times.pop()
-                mean_time = stat.mean(self.times)
-
-                self.logger.debug(
-                    f"Tick: {self.tick}, Mean Time: {str(1/mean_time)}")
 
 
     def save_connection(self, error, state=None):
@@ -272,9 +271,6 @@ class ControllerServer():
         # to connect to any Switch.
         self.logger.debug("Connecting to any Switch")
         self.reconnect_counter = 0
-
-        # Reinitialize initial communication overload protections
-        self.tick = 1
 
         # Reinitialize the protocol
         self.protocol = ControllerProtocol(

--- a/nuxbt/controller/server.py
+++ b/nuxbt/controller/server.py
@@ -7,12 +7,13 @@ import select
 import logging
 import traceback
 import atexit
+from json import dumps
 from threading import Thread
 
 from .controller import Controller, ControllerTypes
 from ..bluez import BlueZ, find_devices_by_alias
 from .protocol import ControllerProtocol
-from .input import InputParser
+from .input import InputParser, DIRECT_INPUT_IDLE_PACKET
 from .utils import format_msg_controller, format_msg_switch
 
 
@@ -125,6 +126,48 @@ class ControllerServer():
     # doesn't drop the controller (replaces the old tick >= 132 counter).
     KEEPALIVE_INTERVAL = 1.0
 
+    def _sync_controller_input(self):
+        """Drain the per-controller task queue and fall back to shared state.
+
+        The hot loop is event-driven for low latency, but the upstream path
+        (WebRTC -> host coalescer -> unix socket) can drop a release event.
+        If we think we are still holding an input but shared state has moved
+        on, re-sync from shared state so we do not stay stuck on a held
+        button/stick indefinitely.
+        """
+
+        if self.task_queue is None:
+            return
+
+        # Drain the task queue every loop. This is cheap when empty and
+        # avoids missed wakeups from the Queue's internal buffer being out
+        # of sync with the pipe that select() watches.
+        try:
+            while True:
+                msg = self.task_queue.get_nowait()
+                if msg and msg["type"] == "macro":
+                    self.input.buffer_macro(msg["macro"], msg["macro_id"])
+                elif msg and msg["type"] == "stop":
+                    self.input.stop_macro(msg["macro_id"], state=self.state)
+                elif msg and msg["type"] == "clear":
+                    self.input.clear_macros()
+                elif msg and msg["type"] == "direct":
+                    self.input.set_controller_input(msg["input"])
+        except queue.Empty:
+            pass
+
+        # Fallback: if direct input is still being held, re-sync from the
+        # shared Manager dict. The main process writes every input packet
+        # there for observers (e.g. the web UI), so it is a reliable
+        # level-triggered view of the latest input even if the edge event
+        # on the queue was lost upstream. We only do this while the local
+        # controller_input believes it is active, so idle cycles pay no
+        # Manager dict IPC cost and macros are not interfered with.
+        if dumps(self.input.controller_input) != dumps(DIRECT_INPUT_IDLE_PACKET):
+            latest = self.state.get("direct_input")
+            if latest is not None:
+                self.input.set_controller_input(latest)
+
     def mainloop(self, itr, ctrl):
 
         # The interrupt socket plus the task queue's read end form the set of
@@ -155,25 +198,7 @@ class ControllerServer():
             except BlockingIOError:
                 reply = None
 
-            # Drain the task queue every loop. This is cheap when empty and
-            # avoids missed wakeups from the Queue's internal buffer being out
-            # of sync with the pipe that select() watches.
-            if self.task_queue is not None:
-                try:
-                    while True:
-                        msg = self.task_queue.get_nowait()
-                        if msg and msg["type"] == "macro":
-                            self.input.buffer_macro(
-                                msg["macro"], msg["macro_id"])
-                        elif msg and msg["type"] == "stop":
-                            self.input.stop_macro(
-                                msg["macro_id"], state=self.state)
-                        elif msg and msg["type"] == "clear":
-                            self.input.clear_macros()
-                        elif msg and msg["type"] == "direct":
-                            self.input.set_controller_input(msg["input"])
-                except queue.Empty:
-                    pass
+            self._sync_controller_input()
 
             self.protocol.process_commands(reply)
             self.input.set_protocol_input(state=self.state)

--- a/nuxbt/controller/server.py
+++ b/nuxbt/controller/server.py
@@ -49,6 +49,10 @@ class ControllerServer():
 
         self.reconnect_counter = 0
 
+        self._crw_running = False
+        self._watchdog_connected_devices = []
+        self._watchdog_connected_devices_count = {}
+
         # Intializing Bluetooth
         self.bt = BlueZ(adapter_path=adapter_path)
 
@@ -110,6 +114,8 @@ class ControllerServer():
             except Exception as e:
                 self.logger.debug("Error during graceful shutdown:")
                 self.logger.debug(traceback.format_exc())
+        finally:
+            self._crw_running = False
 
     # While active input is held (button down/stick tilted/macro running)
     # we resend at the Bluetooth interval so a single lost packet doesn't
@@ -199,6 +205,13 @@ class ControllerServer():
             except BlockingIOError:
                 continue
             except OSError as e:
+                # The interrupt socket died; close the stale sockets before
+                # reconnecting so we don't leak them or hold PSM 17/19.
+                for sock in (itr, ctrl):
+                    try:
+                        sock.close()
+                    except OSError:
+                        pass
                 # Attempt to reconnect to the Switch
                 itr, ctrl = self.save_connection(e)
 
@@ -253,7 +266,7 @@ class ControllerServer():
                         # Switch responds to packets slower during pairing
                         # Pairing cycle responds optimally on a 15Hz loop
                         if not received_first_message:
-                            time.sleep(1)
+                            time.sleep(0.05)
                         else:
                             time.sleep(1/15)
 
@@ -300,41 +313,37 @@ class ControllerServer():
 
         self.state["state"] = "connected"
 
-        self.switch_address = itr.getsockname()[0]
+        # Store the Switch's address (the remote peer), not our own adapter,
+        # so a later reconnect() targets the Switch instead of looping back.
+        self.switch_address = itr.getpeername()[0]
 
         return itr, ctrl
 
     def connection_reset_watchdog(self):
 
-        connected_devices = []
-        connected_devices_count = {}
         while self._crw_running:
             paths = self.bt.find_connected_devices(alias_filter="Nintendo Switch")
-            # Keep track of Switches that connect
             if len(paths) > 0:
-                connected_devices = list(set(connected_devices + paths))
-            
-            # Increment a counter if a Switch connected and disconnected
-            disconnected = list(set(connected_devices) - set(paths))
+                self._watchdog_connected_devices = list(
+                    set(self._watchdog_connected_devices + paths))
+
+            disconnected = list(
+                set(self._watchdog_connected_devices) - set(paths))
             if len(disconnected) > 0:
                 for path in disconnected:
-                    if path not in connected_devices_count.keys():
-                        connected_devices_count[path] = 1
-                    else:
-                        connected_devices_count[path] += 1
-                connected_devices = list(set(connected_devices) - set(disconnected))
-            
-            # Delete Switches that connect/disconnect twice.
-            # This behaviour is characteristic of connection issues and is corrected
-            # by removing the Switch's connection to the system.
-            if len(connected_devices_count.keys()) > 0:
-                for key in connected_devices_count.keys():
-                    if connected_devices_count[key] >= 2:
-                        self.logger.debug(
-                            "A Nintendo Switch disconnected. Resetting Connection...")
-                        self.logger.debug(f"Removing {str(key)}")
-                        self.bt.remove_device(key)
-                        connected_devices_count[key] = 0
+                    self._watchdog_connected_devices_count[path] = (
+                        self._watchdog_connected_devices_count.get(path, 0) + 1
+                    )
+                self._watchdog_connected_devices = list(
+                    set(self._watchdog_connected_devices) - set(disconnected))
+
+            for key, count in list(self._watchdog_connected_devices_count.items()):
+                if count >= 2:
+                    self.logger.debug(
+                        "A Nintendo Switch disconnected. Resetting Connection...")
+                    self.logger.debug(f"Removing {str(key)}")
+                    self.bt.remove_device(key)
+                    self._watchdog_connected_devices_count[key] = 0
 
             time.sleep(0.1)
 
@@ -348,6 +357,7 @@ class ControllerServer():
         # succeeds. This prevents situations where the Switch will
         # disconnect during a connection.
         while True:
+            s_ctrl = s_itr = None
             try:
                 self.state["state"] = "connecting"
 
@@ -360,6 +370,9 @@ class ControllerServer():
                     family=socket.AF_BLUETOOTH,
                     type=socket.SOCK_SEQPACKET,
                     proto=socket.BTPROTO_L2CAP)
+
+                s_ctrl.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s_itr.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
                 # Setting up HID interrupt/control sockets
                 try:
@@ -381,13 +394,11 @@ class ControllerServer():
                 self.bt.set_class("0x02508")
 
                 self._crw_running = True
-                crw = Thread(target = self.connection_reset_watchdog)
+                crw = Thread(target = self.connection_reset_watchdog, daemon=True)
                 crw.start()
 
                 itr, itr_address = s_itr.accept()
                 ctrl, ctrl_address = s_ctrl.accept()
-
-                self._crw_running = False
 
                 # Send an empty input report to the Switch to prompt a reply
                 self.protocol.process_commands(None)
@@ -432,14 +443,16 @@ class ControllerServer():
 
                     # Switch responds to packets slower during pairing
                     # Pairing cycle responds optimally on a 15Hz loop
-                    if not received_first_message:
-                        time.sleep(1)
-                    else:
-                        time.sleep(1/15)
+                    time.sleep(1/15)
                 
                 break
             except OSError as e:
                 self.logger.debug(e)
+                for sock in (s_ctrl, s_itr):
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
 
         self.input.exited_grip_order_menu = False
 
@@ -483,6 +496,8 @@ class ControllerServer():
                     test_itr.close()
                     test_ctrl.close()
                     pass
+                else:
+                    break
         elif type(reconnect_address) == str:
             test_itr, test_ctrl = recreate_sockets()
 
@@ -504,12 +519,10 @@ class ControllerServer():
         msg = self.protocol.get_report()
         itr.sendall(msg)
 
-        # Setting interrupt connection as non-blocking
-        # In this case, non-blocking means it throws a "BlockingIOError"
-        # for sending and receiving, instead of blocking
-        fcntl.fcntl(itr, fcntl.F_SETFL, os.O_NONBLOCK)
-
         return itr, ctrl
 
     def _on_exit(self):
+        self._crw_running = False
+        self._watchdog_connected_devices = []
+        self._watchdog_connected_devices_count = {}
         self.bt.reset_adapter()

--- a/nuxbt/nuxbt.py
+++ b/nuxbt/nuxbt.py
@@ -661,6 +661,7 @@ class Nuxbt():
             # This needs to be done to prevent race conditions
             # on Bluetooth resources.
             if type(controller_index) == int:
+                start = time.time()
                 while True:
                     if controller_index in self.manager_state.keys():
                         state = self.manager_state[controller_index]
@@ -669,6 +670,9 @@ class Nuxbt():
                                 state["state"] == "crashed"):
                             break
 
+                    if time.time() - start > 60:
+                        raise TimeoutError(
+                            "Timed out waiting for controller to initialize")
                     time.sleep(1/30)
         finally:
             self._controller_lock.release()
@@ -716,11 +720,15 @@ class Nuxbt():
         :type controller_index: int
         """
 
+        start = time.time()
         while not self.state[controller_index]["state"] == "connected":
             if self.state[controller_index]["state"] == "crashed":
                 raise OSError("The watched controller has crashe with error",
                               self.state[controller_index]["errors"])
-            pass
+            if time.time() - start > 120:
+                raise TimeoutError(
+                    "Timed out waiting for controller to connect")
+            time.sleep(1/30)
 
     def get_available_adapters(self):
         """Gets the DBus paths of all available Bluetooth

--- a/nuxbt/nuxbt.py
+++ b/nuxbt/nuxbt.py
@@ -137,6 +137,7 @@ class NuxbtCommands(Enum):
     CLEAR_ALL_MACROS = 4
     REMOVE_CONTROLLER = 5
     QUIT = 6
+    SET_INPUT = 7
 
 
 class Nuxbt():
@@ -317,6 +318,10 @@ class Nuxbt():
                     elif msg["command"] == NuxbtCommands.CLEAR_MACROS:
                         cm.clear_macros(
                             msg["arguments"]["controller_index"])
+                    elif msg["command"] == NuxbtCommands.SET_INPUT:
+                        cm.set_controller_input(
+                            msg["arguments"]["controller_index"],
+                            msg["arguments"]["input_packet"])
                     elif msg["command"] == NuxbtCommands.REMOVE_CONTROLLER:
                         index = msg["arguments"]["controller_index"]
                         cm.clear_macros(index)
@@ -543,7 +548,20 @@ class Nuxbt():
         if controller_index not in self.manager_state.keys():
             raise ValueError("Specified controller does not exist")
 
+        # Mirror the latest input into the shared state purely so external
+        # observers (e.g. the web UI) can display it. The controller hot loop
+        # no longer reads this; it receives input as an event below.
         self.manager_state[controller_index]["direct_input"] = input_packet
+
+        # Push the input as an event so the controller's mainloop wakes
+        # immediately (via select) instead of waiting for the next poll tick.
+        self.task_queue.put({
+            "command": NuxbtCommands.SET_INPUT,
+            "arguments": {
+                "controller_index": controller_index,
+                "input_packet": input_packet,
+            }
+        })
 
     def create_input_packet(self):
         """Creates an input packet that is used to specify the input
@@ -852,6 +870,13 @@ class _ControllerManager():
 
         self._controller_queues[index].put({
             "type": "clear",
+        })
+
+    def set_controller_input(self, index, input_packet):
+
+        self._controller_queues[index].put({
+            "type": "direct",
+            "input": input_packet,
         })
 
     def remove_controller(self, index):

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -48,3 +48,50 @@ def test_direct_input_matches_macro_path():
 
     assert _press("PLUS") == plus_macro
     assert _press("MINUS") == minus_macro
+
+
+def test_held_input_reapplied_across_cycles():
+    """A held direct input must be re-applied on every loop cycle, not consumed
+    after the first parse.
+
+    The protocol report is ephemeral: get_report() clears it and
+    process_commands() rebuilds a neutral baseline each cycle. The controller
+    mainloop only receives a SET_INPUT event when the input *changes*, then
+    resends the report at the Bluetooth interval in between. If set_protocol_input
+    consumed the input (controller_input -> None) those resends would carry a
+    neutral report and the input would stutter (regression test)."""
+    proto, parser = _make_parser()
+    proto.device_info_queried = True  # required for buttons to reach the report
+
+    pkt = copy.deepcopy(DIRECT_INPUT_IDLE_PACKET)
+    pkt["A"] = True
+    parser.set_controller_input(pkt)  # single "A pressed" event
+
+    # Simulate several mainloop cycles with no further input events.
+    for _ in range(5):
+        proto.process_commands(None)      # rebuild neutral baseline
+        parser.set_protocol_input()
+        report = proto.get_report()       # send + clear
+        # A is bit 3 (0x08) of the upper button byte, report[4].
+        assert report[4] & 0x08, "held A must persist on resends"
+
+
+def test_release_clears_held_input():
+    """Releasing to an idle packet must drop the held input from the report."""
+    proto, parser = _make_parser()
+    proto.device_info_queried = True
+
+    pressed = copy.deepcopy(DIRECT_INPUT_IDLE_PACKET)
+    pressed["A"] = True
+    parser.set_controller_input(pressed)
+    proto.process_commands(None)
+    parser.set_protocol_input()
+    assert proto.get_report()[4] & 0x08
+    assert parser.active_input_queued()
+
+    # Release: idle packet event.
+    parser.set_controller_input(copy.deepcopy(DIRECT_INPUT_IDLE_PACKET))
+    assert not parser.active_input_queued()
+    proto.process_commands(None)
+    parser.set_protocol_input()
+    assert not proto.get_report()[4] & 0x08

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,0 +1,50 @@
+import copy
+import sys
+from unittest.mock import MagicMock
+
+# nuxbt's package __init__ pulls in dbus; mock it for headless tests.
+if 'dbus' not in sys.modules:
+    sys.modules['dbus'] = MagicMock()
+
+from nuxbt.controller.protocol import ControllerProtocol
+from nuxbt.controller.controller import ControllerTypes
+from nuxbt.controller.input import InputParser, DIRECT_INPUT_IDLE_PACKET
+
+
+def _make_parser():
+    proto = ControllerProtocol(ControllerTypes.PRO_CONTROLLER, "00:11:22:33:44:55")
+    return proto, InputParser(proto)
+
+
+def _press(button):
+    pkt = copy.deepcopy(DIRECT_INPUT_IDLE_PACKET)
+    pkt[button] = True
+    proto, parser = _make_parser()
+    parser.parse_controller_input(pkt)
+    # report[5] is the "shared" middle button byte of the standard input report.
+    return proto.report[5]
+
+
+def test_direct_input_plus_minus_bits():
+    """Direct input must pack Plus/Minus per the Switch HID spec:
+    shared byte bit 0 = Minus, bit 1 = Plus (regression test for the swap)."""
+    # Minus -> bit 0 only
+    assert _press("MINUS") & 0x01
+    assert not _press("MINUS") & 0x02
+    # Plus -> bit 1 only
+    assert _press("PLUS") & 0x02
+    assert not _press("PLUS") & 0x01
+
+
+def test_direct_input_matches_macro_path():
+    """The direct path and the macro path must pack Plus/Minus identically."""
+    proto_m, parser_m = _make_parser()
+    parser_m.set_macro_input(["PLUS", "0.1s"])
+    plus_macro = proto_m.report[5]
+
+    proto_m, parser_m = _make_parser()
+    parser_m.set_macro_input(["MINUS", "0.1s"])
+    minus_macro = proto_m.report[5]
+
+    assert _press("PLUS") == plus_macro
+    assert _press("MINUS") == minus_macro

--- a/tests/test_nuxbt.py
+++ b/tests/test_nuxbt.py
@@ -123,3 +123,27 @@ class TestNuxbt:
             macro_string = "A 0.1s"
             result_id = nuxbt_instance.macro(0, macro_string, block=True)
             assert result_id == macro_id_holder[0]
+
+    def test_set_controller_input(self, nuxbt_instance):
+        """Direct input is mirrored into state (for observers like the web UI)
+        and enqueued as a SET_INPUT event so the controller loop wakes
+        immediately instead of polling."""
+        nuxbt_instance.manager_state[0] = {}
+
+        packet = nuxbt_instance.create_input_packet()
+        packet["A"] = True
+        nuxbt_instance.set_controller_input(0, packet)
+
+        # Mirror for external observers
+        assert nuxbt_instance.manager_state[0]["direct_input"] == packet
+
+        # Event for the controller hot loop
+        msg = nuxbt_instance.task_queue.get(timeout=1)
+        assert msg["command"] == NuxbtCommands.SET_INPUT
+        assert msg["arguments"]["controller_index"] == 0
+        assert msg["arguments"]["input_packet"] == packet
+
+    def test_set_controller_input_unknown_index(self, nuxbt_instance):
+        """Setting input on a non-existent controller raises."""
+        with pytest.raises(ValueError, match="does not exist"):
+            nuxbt_instance.set_controller_input(99, {})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,119 @@
+import copy
+import multiprocessing
+import queue
+import sys
+from unittest.mock import MagicMock
+
+# nuxbt's package __init__ pulls in dbus; mock it for headless tests.
+if 'dbus' not in sys.modules:
+    sys.modules['dbus'] = MagicMock()
+
+# nuxbt.controller.server imports fcntl, which is not available on Windows.
+if 'fcntl' not in sys.modules:
+    sys.modules['fcntl'] = MagicMock()
+
+# nuxbt.nuxbt forces 'fork' start method, which is unavailable on Windows.
+multiprocessing.set_start_method = MagicMock()
+
+# nuxbt.agent imports PyGObject's GLib, which may not be installed on Windows.
+if 'gi' not in sys.modules:
+    sys.modules['gi'] = MagicMock()
+    sys.modules['gi.repository'] = MagicMock()
+    sys.modules['gi.repository.GLib'] = MagicMock()
+
+from nuxbt.controller.server import ControllerServer
+from nuxbt.controller.controller import ControllerTypes
+from nuxbt.controller.input import InputParser, DIRECT_INPUT_IDLE_PACKET
+from nuxbt.controller.protocol import ControllerProtocol
+
+
+class DummyServer:
+    """Minimal stand-in for ControllerServer so _sync_controller_input can be
+    unit-tested without spinning up Bluetooth/BlueZ."""
+    pass
+
+
+def _make_server():
+    proto = ControllerProtocol(ControllerTypes.PRO_CONTROLLER, "00:11:22:33:44:55")
+    server = DummyServer()
+    server.input = InputParser(proto)
+    server.task_queue = queue.Queue()
+    server.state = {}
+    return server
+
+
+def test_sync_controller_input_drains_direct_event():
+    """A direct input event on the queue updates controller_input."""
+    server = _make_server()
+    pressed = copy.deepcopy(DIRECT_INPUT_IDLE_PACKET)
+    pressed["A"] = True
+    server.task_queue.put({"type": "direct", "input": pressed})
+
+    ControllerServer._sync_controller_input(server)
+
+    assert server.input.active_input_queued()
+    assert server.task_queue.empty()
+
+
+def test_sync_controller_input_fallback_to_shared_state_on_dropped_release():
+    """If the neutral queue event was lost upstream, shared state still has the
+    latest idle packet; re-sync from it so we don't stay stuck on a held input."""
+    server = _make_server()
+
+    # Simulate a stale held input (the release event never reached us).
+    pressed = copy.deepcopy(DIRECT_INPUT_IDLE_PACKET)
+    pressed["A"] = True
+    server.input.set_controller_input(pressed)
+    assert server.input.active_input_queued()
+
+    # Meanwhile the main process already updated shared state to idle.
+    server.state["direct_input"] = copy.deepcopy(DIRECT_INPUT_IDLE_PACKET)
+
+    ControllerServer._sync_controller_input(server)
+
+    assert not server.input.active_input_queued()
+    assert server.task_queue.empty()
+
+
+def test_sync_controller_input_does_not_read_shared_state_when_idle():
+    """When controller_input is already idle, the fallback should not read the
+    Manager dict; this keeps idle cycles cheap and avoids touching stale state."""
+    server = _make_server()
+    server.input.set_controller_input(copy.deepcopy(DIRECT_INPUT_IDLE_PACKET))
+    # Intentionally invalid shared state; if it were read it would corrupt
+    # controller_input. Because we are idle, it must be ignored.
+    server.state["direct_input"] = {"should_not_be_read": True}
+
+    ControllerServer._sync_controller_input(server)
+
+    assert not server.input.active_input_queued()
+    assert server.input.controller_input == DIRECT_INPUT_IDLE_PACKET
+
+
+def test_sync_controller_input_queue_event_wins_over_shared_state():
+    """When both a queue event and shared state are available, the queue event
+    (the explicit edge) takes precedence over the fallback poll."""
+    server = _make_server()
+
+    # Shared state says A is still pressed.
+    pressed = copy.deepcopy(DIRECT_INPUT_IDLE_PACKET)
+    pressed["A"] = True
+    server.state["direct_input"] = pressed
+
+    # But a queue event says it was released.
+    server.task_queue.put({"type": "direct", "input": copy.deepcopy(DIRECT_INPUT_IDLE_PACKET)})
+
+    ControllerServer._sync_controller_input(server)
+
+    assert not server.input.active_input_queued()
+
+
+def test_sync_controller_input_macro_event_still_processed():
+    """Macro events on the queue are still drained alongside direct input."""
+    server = _make_server()
+    server.task_queue.put({"type": "macro", "macro": "A 0.1s", "macro_id": "abc123"})
+
+    ControllerServer._sync_controller_input(server)
+
+    assert server.input.macro_buffer
+    assert server.task_queue.empty()


### PR DESCRIPTION
## Summary

The event-driven select() loop introduced in #70 only updates controller_input when a per-controller queue event arrives. If a release (neutral) event is dropped upstream — WebRTC unreliable DataChannel, host coalescer, or unix socket — controller_input stays non-IDLE and the Switch sees a held button/stick indefinitely.

This PR adds a level-triggered fallback: while controller_input believes it is active, re-sync from the shared Manager dict that the main process keeps up to date for observers (web UI). This recovers a dropped neutral event on the next active cycle (~7.6 ms) without reintroducing full-time polling or interfering with macros.

## Changes

- Extract input sync logic into _sync_controller_input() in ControllerServer.
- Drain queue events first (fast path), then fall back to shared state only when controller_input is non-IDLE.
- Add unit tests in 	ests/test_server.py covering queue drain, fallback recovery, idle-cycle optimization, queue-priority, and macro handling.

## Related

- Builds on top of ix/pairing-handshake-reconnect so both fixes can be validated together before merging to main.
- Regression safety: the fallback is a no-op when queue events arrive normally, and it does not consume controller_input, so the held-input re-apply fix remains intact.